### PR TITLE
NA-0: Bump next-mdx-remote dependency to resolve deployment error

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "gray-matter": "^4.0.3",
     "lint-staged": "^16.1.5",
     "next": "^16.0.10",
-    "next-mdx-remote": "^5.0.0",
+    "next-mdx-remote": "^6.0.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-icons": "^5.5.0",


### PR DESCRIPTION
This PR resolves this error that was reported during deployment:

`
Error: Vulnerable version of next-mdx-remote detected (5.0.0). Please update to version 6.0.0 or later. Learn More: https://vercel.link/CVE-2026-0969
`